### PR TITLE
Add continuous integration with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
     - make
     - sudo make install
     - nasm --version
+    - cd ..
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: c
+
+compiler:
+ - gcc
+ - clang
+
+script:
+ - make
+ - make testavx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
 language: c
 
+install:
+    - wget https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.xz
+    - tar -xvf nasm-2.14.02.tar.xz
+    - cd nasm-2.14.02
+    - ./configure
+    - make
+    - sudo make install
+    - nasm --version
+
 jobs:
-  include
+  include:
   - name: "Make (GCC)"
     compiler: gcc
     script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: c
 
-compiler:
- - gcc
- - clang
-
-script:
- - make
- - make testavx
+jobs:
+  include
+  - name: "Make (GCC)"
+    compiler: gcc
+    script: make
+  - name: "Make (Clang)"
+    compiler: clang
+    script: make
+  - name: "Make testavx (GCC)"
+    compiler: gcc
+    script: make testavx
+  - name: "Make testavx (Clang)"
+    compiler: clang
+    script: make testavx

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ install:
     - nasm --version
     - cd ..
 
+before_script: git submodule update --init --recursive
+
 jobs:
   include:
   - name: "Make (GCC)"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AV1 video decoder in WASM demo
+# AV1 video decoder in WASM demo  [![Travis Build Status](https://travis-ci.org/GoogleChromeLabs/wasm-av1.svg?branch=master)](https://travis-ci.org/GoogleChromeLabs/wasm-av1)
 
 In-browser AV1 video decoder demo for experimenting with codecs.
 


### PR DESCRIPTION
Adds continuous integration with Travis. Currently outputs the following error on the regular `make` job:
```
emcc -o decode-av1.js -O3 -s WASM=1 \
				-s ALLOW_MEMORY_GROWTH=1 \
				-s EXPORTED_FUNCTIONS="['_AVX_Decoder_new', \
										'_AVX_Decoder_destroy', \
										'_AVX_Decoder_set_source', \
										'_AVX_Decoder_run', \
										'_AVX_Decoder_get_width', \
										'_AVX_Decoder_get_height', \
										'_AVX_Decoder_video_finished', \
										'_AVX_Decoder_get_frame', \
										'_AVX_Video_Frame_get_buffer', \
										'_AVX_YUV_to_RGB', \
										'_DS_open', \
										'_DS_close', \
										'_DS_set_blob', \
										'_malloc', '_free' \
									   ]" \
				blob-api.c yuv-to-rgb.c decode-av1.c -I third_party/aom -I third_party/embuild -L third_party/embuild -laom
/bin/sh: 1: emcc: not found
make: *** [decode-av1.js] Error 127
The command "make" exited with 2.
```
And the following error on the `make testavx` run:
```
make[1]: Leaving directory `/home/travis/build/EwoutH/wasm-av1/third_party/build'
cc -o testavx -O3 test.c decode-av1.c -I third_party/aom -I third_party/embuild -L third_party/build -laom
In file included from third_party/aom/aom_ports/mem_ops.h:61:0,
                 from decode-av1.c:31:
third_party/aom/aom_ports/mem_ops_aligned.h:94:24: fatal error: aom_config.h: No such file or directory
 #include "aom_config.h"
                        ^
compilation terminated.
make: *** [testavx] Error 1
The command "make testavx" exited with 2.
```
Full runs can be viewed here: https://travis-ci.com/EwoutH/wasm-av1